### PR TITLE
fix: project insert policy

### DIFF
--- a/migrations/committed/000010.sql
+++ b/migrations/committed/000010.sql
@@ -1,0 +1,6 @@
+--! Previous: sha1:c91904717572ef673c9e3b74f8d937d8dda75364
+--! Hash: sha1:d867d67bd7c5432019e3785db957b7f6fdc3d623
+
+ALTER POLICY project_insert_policy ON project
+TO auth_user
+WITH CHECK (true);

--- a/migrations/schema_snapshot.sql
+++ b/migrations/schema_snapshot.sql
@@ -1199,8 +1199,7 @@ ALTER TABLE public.project ENABLE ROW LEVEL SECURITY;
 -- Name: project project_insert_policy; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY project_insert_policy ON public.project FOR INSERT TO auth_user WITH CHECK ((admin_wallet_id IN ( SELECT get_current_addrs.wallet_id
-   FROM public.get_current_addrs() get_current_addrs(wallet_id, addr, profile_type))));
+CREATE POLICY project_insert_policy ON public.project FOR INSERT TO auth_user WITH CHECK (true);
 
 
 --

--- a/server/__tests__/db/project.insert.policy.test.ts
+++ b/server/__tests__/db/project.insert.policy.test.ts
@@ -1,50 +1,20 @@
 import { PoolClient } from 'pg';
 import { genRandomRegenAddress } from '../utils';
-import {
-  becomeAuthUser,
-  createAccount,
-  withAuthUserDb,
-  withRootDb,
-} from './helpers';
+import { becomeUser, withAuthUserDb, withRootDb } from './helpers';
 
 describe('the INSERT RLS policy for the project table...', () => {
-  it('should allow a user to create a project with their own wallet as admin...', async () => {
+  it('should allow auth_users to insert', async () => {
     const walletAddr = genRandomRegenAddress();
     await withAuthUserDb(walletAddr, async (client: PoolClient) => {
-      const addrsQ = await client.query(
-        'select wallet_id from get_current_addrs() where addr=$1',
-        [walletAddr],
-      );
-      const [{ wallet_id }] = addrsQ.rows;
-      const insQuery = await client.query(
-        'INSERT INTO project (admin_wallet_id) VALUES ($1)',
-        [wallet_id],
-      );
+      const insQuery = await client.query('INSERT INTO project DEFAULT VALUES');
       expect(insQuery.rowCount).toBe(1);
     });
   });
-
-  it('should NOT allow a user to create a project with another users wallet as admin...', async () => {
-    const walletAddr = genRandomRegenAddress();
-    const walletAddr2 = genRandomRegenAddress();
+  it('should not allow any app_user to insert', async () => {
     await withRootDb(async (client: PoolClient) => {
-      const accountId = await createAccount(client, walletAddr);
-      const accountId2 = await createAccount(client, walletAddr2);
-      // get the wallet_id for the first user
-      await becomeAuthUser(client, walletAddr, accountId);
-      const addrsQ = await client.query(
-        'select wallet_id from get_current_addrs() where addr=$1',
-        [walletAddr],
-      );
-      const [{ wallet_id }] = addrsQ.rows;
-      // switch the second user
-      await becomeAuthUser(client, walletAddr2, accountId2);
-      // try to insert the first users wallet_id as admin_wallet_id
-      // this operation should fail
-      await expect(
-        client.query('INSERT INTO project (admin_wallet_id) VALUES ($1)', [
-          wallet_id,
-        ]),
+      await becomeUser(client, 'app_user');
+      expect(
+        client.query('INSERT INTO project DEFAULT VALUES'),
       ).rejects.toThrow(
         'new row violates row-level security policy for table "project"',
       );


### PR DESCRIPTION
## Description

Related to regen-network/rnd-dev-team#1791

If a user tries to update a "purely" on-chain project (which has been created through the CLI for instance, meaning there's no off-chain project yet for it), the UI will create an off-chain project as part of that.
In particular, if the user first tries to update from the UI the admin for this project, it was failing because of the existing insert policy on project since it only allows the current user to be an admin for the created project and in this particular use case, the admin is different from the current user addr.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] targeted `dev` branch
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
