### PR TITLE
fix: move @types/cookie-session to dep instead of devDep

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
     "@keyv/postgres": "^1.3.1",
     "@keyv/redis": "^2.1.2",
     "@sentry/node": "^7.11.1",
+    "@types/cookie-session": "^2.0.44",
     "@types/cors": "^2.8.13",
     "@types/express": "4.17.14",
     "@types/html-to-text": "^5.1.1",
@@ -68,7 +69,6 @@
   },
   "devDependencies": {
     "@types/cookie-parser": "^1.4.3",
-    "@types/cookie-session": "^2.0.44",
     "@types/passport-google-oauth20": "^2.0.12",
     "@types/swagger-jsdoc": "^6.0.1",
     "@types/swagger-ui-express": "^4.1.3",


### PR DESCRIPTION
## Description

Getting the following error in heroku: `server: middleware/loginHelpers.ts(7,11): error TS2339: Property 'session' does not exist on type 'UserRequest'.` because `req.session` comes from `@types/cookie-session`

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted `dev` branch
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
