### PR TITLE
fix: move @types/express-fileupload to dep

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,7 @@
     "@types/cookie-session": "^2.0.44",
     "@types/cors": "^2.8.13",
     "@types/express": "4.17.14",
+    "@types/express-fileupload": "^1.4.4",
     "@types/html-to-text": "^5.1.1",
     "@types/lodash": "^4.14.155",
     "@types/mjml": "^4.0.4",
@@ -69,7 +70,6 @@
   },
   "devDependencies": {
     "@types/cookie-parser": "^1.4.3",
-    "@types/express-fileupload": "^1.4.4",
     "@types/passport-google-oauth20": "^2.0.12",
     "@types/swagger-jsdoc": "^6.0.1",
     "@types/swagger-ui-express": "^4.1.3",


### PR DESCRIPTION
## Description

Moving @types/express-fileupload away from dev dep to dep so the app doesn't crash on heroku.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted `dev` branch
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
