### PR TITLE
fix: logout session auth accounts

### DIFF
--- a/server/__tests__/utils.ts
+++ b/server/__tests__/utils.ts
@@ -207,7 +207,9 @@ export async function createNewUser(): Promise<CreateNewUser> {
   return { userPrivKey, userPubKey, userAddr };
 }
 
-export async function createNewUserAndLogin(): Promise<CreateNewUserAndLogin> {
+export async function createNewUserAndLogin(
+  headers?: Headers,
+): Promise<CreateNewUserAndLogin> {
   const { userPrivKey, userPubKey, userAddr } = await createNewUser();
   const nonce = '';
   const loginResp = await performLogin(
@@ -215,6 +217,7 @@ export async function createNewUserAndLogin(): Promise<CreateNewUserAndLogin> {
     userPubKey,
     userAddr,
     nonce,
+    headers,
   );
   return { ...loginResp, userAddr, userPrivKey, userPubKey };
 }

--- a/server/routes/wallet-auth.ts
+++ b/server/routes/wallet-auth.ts
@@ -39,10 +39,11 @@ walletAuth.post(
       req.session = null;
       if (err) {
         next(err);
+      } else {
+        return res.send({
+          message: 'You have been logged out!',
+        });
       }
-    });
-    return res.send({
-      message: 'You have been logged out!',
     });
   },
 );

--- a/server/routes/wallet-auth.ts
+++ b/server/routes/wallet-auth.ts
@@ -36,6 +36,7 @@ walletAuth.post(
   ensureLoggedIn(),
   (req, res, next) => {
     req.logout(err => {
+      req.session = null;
       if (err) {
         next(err);
       }


### PR DESCRIPTION
## Description

If you log out from account A, then log in with account B, account A was still part of the authenticated accounts list, which shouldn't be the case. Logging out should log you out from all authenticated accounts.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted `dev` branch
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
