### PR TITLE
chore: only run ci on branches dev and master

### DIFF
--- a/.github/workflows/registryServer.yml
+++ b/.github/workflows/registryServer.yml
@@ -3,9 +3,7 @@ name: registry-server
 on:
   pull_request:
   push:
-    branches:
-      - '**'
-      - '!master'
+    branches: [master, dev]
 
 jobs:
   lint-and-format:


### PR DESCRIPTION
## Description

ref: https://github.com/regen-network/regen-server/pull/455

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted `dev` branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
