### PR TITLE
feat(irigen): Add CLI functionality for generating raw IRI in yarn script

### DIFF
--- a/iri-gen/index.ts
+++ b/iri-gen/index.ts
@@ -66,7 +66,7 @@ async function main(): Promise<void> {
   const argv = minimist(process.argv.slice(2), { boolean: true });
   // Make sure we got a filename on the command line.
   if (argv._.length < 1) {
-    console.log('You should provide the path to a file');
+    console.log('File path is required');
     process.exit(1);
   }
   const insertFlag = argv.insert;

--- a/iri-gen/index.ts
+++ b/iri-gen/index.ts
@@ -16,7 +16,7 @@ async function readGraphDocument(
 }
 
 async function runGraphIRIGen(
-  filePath: string,
+  filePath: fs.PathOrFileDescriptor,
   insertFlag: boolean,
 ): Promise<void> {
   let client: PoolClient;

--- a/iri-gen/index.ts
+++ b/iri-gen/index.ts
@@ -1,34 +1,30 @@
 import * as fs from 'fs';
-import { generateIRIFromGraph } from './iri-gen';
+import path from 'path';
+import { generateIRIFromGraph, generateIRIFromRaw } from './iri-gen';
 import 'dotenv/config';
 import { pgPool } from 'common/pool';
 import minimist from 'minimist';
 import { PoolClient } from 'pg';
 import { MetadataGraph } from 'common/metadata_graph';
 
-async function readDocument(
-  path: fs.PathOrFileDescriptor,
+async function readGraphDocument(
+  filePath: fs.PathOrFileDescriptor,
 ): Promise<{ doc: { [key: string]: number | string | boolean }; iri: string }> {
-  const rawdata = fs.readFileSync(path);
+  const rawdata = fs.readFileSync(filePath);
   const doc = JSON.parse(rawdata.toString());
   return doc;
 }
 
-async function main(): Promise<void> {
-  const argv = minimist(process.argv.slice(2), { boolean: true });
-  // Make sure we got a filename on the command line.
-  if (argv._.length < 1) {
-    console.log('You should provide the path to a JSON file');
-    process.exit(1);
-  }
-  const insertFlag = argv.insert;
-  const path = argv._[0];
+async function runGraphIRIGen(
+  filePath: string,
+  insertFlag: boolean,
+): Promise<void> {
   let client: PoolClient;
   try {
-    const doc = await readDocument(path);
+    const doc = await readGraphDocument(filePath);
     const iri = await generateIRIFromGraph(doc);
     if (iri) {
-      console.log(`The IRI for ${path} is: ${iri}`);
+      console.log(`The IRI for ${filePath} is: ${iri}`);
       if (insertFlag) {
         client = await pgPool.connect();
         console.log('Inserting IRI, and metadata into metadata_graph table.');
@@ -45,6 +41,43 @@ async function main(): Promise<void> {
     process.exit(1);
   } finally {
     if (client) client.release();
+  }
+}
+
+async function runRawIRIGen(filePath: string): Promise<void> {
+  try {
+    // trim first character from extension, as "foo.json"
+    // will return ".json" from path.extname()
+    const extension = path.extname(filePath).slice(1);
+    const rawdata = fs.readFileSync(filePath);
+
+    const iri = await generateIRIFromRaw(rawdata, extension);
+    if (iri) {
+      console.log(`The IRI for ${filePath} is: ${iri}`);
+      process.exit(0);
+    }
+  } catch (e) {
+    console.log(e);
+    process.exit(1);
+  }
+}
+
+async function main(): Promise<void> {
+  const argv = minimist(process.argv.slice(2), { boolean: true });
+  // Make sure we got a filename on the command line.
+  if (argv._.length < 1) {
+    console.log('You should provide the path to a file');
+    process.exit(1);
+  }
+  const insertFlag = argv.insert;
+  const rawFlag = argv.raw;
+  const filePath = argv._[0];
+  const extension = path.extname(filePath).slice(1);
+
+  if (extension == 'json' && !rawFlag) {
+    runGraphIRIGen(filePath, insertFlag);
+  } else {
+    runRawIRIGen(filePath);
   }
 }
 


### PR DESCRIPTION
## Description

Closes: https://regennetwork.atlassian.net/browse/APP-96

Adds support for generating IRI's for raw datasets.  Full functionality is now as follows:
- `yarn gen [path/to/file.json]` will generate an IRI using a graph content hash by default for all JSON files (and can insert to Postgres when the `--insert` flag is added)
- `yarn gen [path/to/file.pdf]` will generate an IRI using a raw content hash for any other filetype extension besides JSON
- `yarn gen [path/to/file.json] --raw` can be used (adding the `--raw` flag) if one wants to use a raw content hash for IRI generation of a JSON file.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted `dev` branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
