### PR TITLE
feat: APP-111 choose redirect google oauth route based on state from query param

### DIFF
--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -23,16 +23,23 @@ runnerPromise.then(res => {
 
 const router = express.Router();
 
-router.get('/google', passport.authenticate('google', { scope: ['email'] }));
+router.get('/google', (req, res, next) => {
+  const state = JSON.stringify(req.query);
+  passport.authenticate('google', { scope: ['email'], state })(req, res, next);
+});
 
 router.get(
   GOOGLE_CALLBACK_URL,
   passport.authenticate('google', {
     failureRedirect: process.env.MARKETPLACE_APP_URL,
   }),
-  function (req, res) {
+  function (req: UserRequest, res) {
+    let route = 'profile';
+    if (req.user?.state?.createProject) {
+      route = 'project-pages/draft/basic-info';
+    }
     updateActiveAccounts(req);
-    res.redirect(`${process.env.MARKETPLACE_APP_URL}/profile`);
+    res.redirect(`${process.env.MARKETPLACE_APP_URL}/${route}`);
   },
 );
 

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -34,10 +34,7 @@ router.get(
     failureRedirect: process.env.MARKETPLACE_APP_URL,
   }),
   function (req: UserRequest, res) {
-    let route = 'profile';
-    if (req.user?.state?.createProject) {
-      route = 'project-pages/draft/basic-info';
-    }
+    const route = req.user?.state?.route || 'profile';
     updateActiveAccounts(req);
     res.redirect(`${process.env.MARKETPLACE_APP_URL}/${route}`);
   },

--- a/server/types.ts
+++ b/server/types.ts
@@ -3,7 +3,7 @@ import { Request } from 'express';
 export interface User {
   sub?: string;
   accountId?: string;
-  state?: { createProject?: string };
+  state?: { route?: string };
 }
 
 export interface UserRequest extends Request {

--- a/server/types.ts
+++ b/server/types.ts
@@ -3,6 +3,7 @@ import { Request } from 'express';
 export interface User {
   sub?: string;
   accountId?: string;
+  state?: { createProject?: string };
 }
 
 export interface UserRequest extends Request {


### PR DESCRIPTION
## Description

Part of: https://regennetwork.atlassian.net/jira/software/c/projects/ENG/boards/51?selectedIssue=APP-111

This is to allow to redirect to the project creation basic info form after logging in with google instead of the user profile page (default). On the front-end, this will be achieved by passing a query parameter `createProject` to /auth/google endpoint.

See flow on https://www.figma.com/file/OBJXPR0vdjnWb9fOYHA6Sg/Add-more-CTAs-to-list-a-project?type=design&node-id=9-11756&mode=design&t=LBznjJd7SfFhRQuZ-0

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted `dev` branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
