### PR TITLE
fix: APP-114 allow profile media deletion

### DIFF
--- a/.github/workflows/registryServer.yml
+++ b/.github/workflows/registryServer.yml
@@ -37,6 +37,7 @@ jobs:
       GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
       PASSCODE_MAX_TRY_COUNT: 3
       S3_PROJECTS_PATH: projects-test
+      S3_PROFILES_PATH: profiles-test
       IMAGE_STORAGE_URL: ${{ secrets.IMAGE_STORAGE_URL }}
 
     strategy:

--- a/server/.env-test
+++ b/server/.env-test
@@ -7,3 +7,4 @@ CSRF_COOKIE_NAME=__Host-regen-dev.x-csrf-token
 AWS_BUCKET_REGION=us-east-1
 AWS_S3_BUCKET=regen-registry
 S3_PROJECTS_PATH=projects-test
+S3_PROFILES_PATH=profiles-test

--- a/server/__tests__/e2e/files.profiles.test.ts
+++ b/server/__tests__/e2e/files.profiles.test.ts
@@ -8,54 +8,127 @@ import {
 } from '../utils';
 
 describe('files endpoint, profiles auth...', () => {
-  it(
-    'allows a user to upload profile media...',
-    async () => {
-      const { authHeaders } = await createNewUserAndLogin();
+  describe('upload profile media', () => {
+    it(
+      'allows a user to upload profile media...',
+      async () => {
+        const { authHeaders } = await createNewUserAndLogin();
 
-      const query = await fetch(`${getMarketplaceURL()}/graphql`, {
-        method: 'POST',
-        headers: authHeaders,
-        body: JSON.stringify({
-          query: '{ getCurrentAccount { id } }',
-        }),
-      });
-      const result = await query.json();
-      const accountId = result.data.getCurrentAccount.id;
-      const key = `profiles-test/${accountId}`;
-      const fname = `test-${accountId}.txt`;
+        const query = await fetch(`${getMarketplaceURL()}/graphql`, {
+          method: 'POST',
+          headers: authHeaders,
+          body: JSON.stringify({
+            query: '{ getCurrentAccount { id } }',
+          }),
+        });
+        const result = await query.json();
+        const accountId = result.data.getCurrentAccount.id;
+        const key = `${process.env.S3_PROFILES_PATH}/${accountId}`;
+        const fname = `test-${accountId}.txt`;
 
-      try {
+        try {
+          const { resp } = await dummyFilesSetup(
+            key,
+            fname,
+            accountId,
+            authHeaders,
+          );
+          expect(resp.status).toBe(200);
+        } finally {
+          await dummyFilesTeardown(key, fname);
+        }
+      },
+      longerTestTimeout,
+    );
+    it(
+      'does not allow a user to update another users media...',
+      async () => {
+        const { authHeaders } = await createNewUserAndLogin();
+
+        const accountId = 'another-users-uuid';
+        const key = `${process.env.S3_PROFILES_PATH}/${accountId}`;
+        const fname = `test-${accountId}.txt`;
+
         const { resp } = await dummyFilesSetup(
           key,
           fname,
           accountId,
           authHeaders,
         );
-        expect(resp.status).toBe(200);
-      } finally {
-        await dummyFilesTeardown(key, fname);
-      }
-    },
-    longerTestTimeout,
-  );
-  it(
-    'does not allow a user to update another users media...',
-    async () => {
-      const { authHeaders } = await createNewUserAndLogin();
+        expect(resp.status).toBe(401);
+      },
+      longerTestTimeout,
+    );
+  });
+  describe('delete profile media', () => {
+    it(
+      'allows a user to delete profile media...',
+      async () => {
+        const { authHeaders } = await createNewUserAndLogin();
 
-      const accountId = 'another-users-uuid';
-      const key = `profiles-test/${accountId}`;
-      const fname = `test-${accountId}.txt`;
+        const query = await fetch(`${getMarketplaceURL()}/graphql`, {
+          method: 'POST',
+          headers: authHeaders,
+          body: JSON.stringify({
+            query: '{ getCurrentAccount { id } }',
+          }),
+        });
+        const result = await query.json();
+        const accountId = result.data.getCurrentAccount.id;
+        const key = `${process.env.S3_PROFILES_PATH}/${accountId}`;
+        const fname = `test-${accountId}.txt`;
 
-      const { resp } = await dummyFilesSetup(
-        key,
-        fname,
-        accountId,
-        authHeaders,
-      );
-      expect(resp.status).toBe(401);
-    },
-    longerTestTimeout,
-  );
+        try {
+          await dummyFilesSetup(key, fname, accountId, authHeaders);
+          const resp = await fetch(
+            `${getMarketplaceURL()}/files/${
+              process.env.S3_PROFILES_PATH
+            }/${accountId}?fileName=${fname}`,
+            {
+              method: 'DELETE',
+              headers: authHeaders,
+            },
+          );
+          expect(resp.status).toBe(200);
+        } finally {
+          await dummyFilesTeardown(key, fname);
+        }
+      },
+      longerTestTimeout,
+    );
+    it(
+      'does not allow a user to delete another users media...',
+      async () => {
+        const { authHeaders } = await createNewUserAndLogin();
+
+        const query = await fetch(`${getMarketplaceURL()}/graphql`, {
+          method: 'POST',
+          headers: authHeaders,
+          body: JSON.stringify({
+            query: '{ getCurrentAccount { id } }',
+          }),
+        });
+        const result = await query.json();
+        const accountId = result.data.getCurrentAccount.id;
+
+        const key = `${process.env.S3_PROFILES_PATH}/${accountId}`;
+        const fname = `test-${accountId}.txt`;
+
+        await dummyFilesSetup(key, fname, accountId, authHeaders);
+
+        const { authHeaders: authHeaders1 } = await createNewUserAndLogin();
+        const resp = await fetch(
+          `${getMarketplaceURL()}/files/${
+            process.env.S3_PROFILES_PATH
+          }/${accountId}?fileName=${fname}`,
+          {
+            method: 'DELETE',
+            headers: authHeaders1,
+          },
+        );
+        expect(resp.status).toBe(401);
+      },
+      longerTestTimeout,
+    );
+  });
 });

--- a/server/__tests__/e2e/files.projects.test.ts
+++ b/server/__tests__/e2e/files.projects.test.ts
@@ -87,7 +87,9 @@ describe('files endpoint, projects auth...', () => {
           );
           const json = await uploadResp.json();
           const resp = await fetch(
-            `${getMarketplaceURL()}/files/${projectId}/${fname}`,
+            `${getMarketplaceURL()}/files/${
+              process.env.S3_PROJECTS_PATH
+            }/${projectId}?fileName=${fname}`,
             {
               method: 'DELETE',
               headers: authHeaders,
@@ -122,7 +124,9 @@ describe('files endpoint, projects auth...', () => {
           // Try to delete project media administered by another account
           const { authHeaders: authHeaders1 } = await createNewUserAndLogin();
           const resp = await fetch(
-            `${getMarketplaceURL()}/files/${projectId}/${fname}`,
+            `${getMarketplaceURL()}/files/${
+              process.env.S3_PROJECTS_PATH
+            }/${projectId}?fileName=${fname}`,
             {
               method: 'DELETE',
               headers: authHeaders1,

--- a/server/routes/files.ts
+++ b/server/routes/files.ts
@@ -16,11 +16,13 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { UploadedFile } from 'express-fileupload';
 import { generateIRIFromRaw } from 'iri-gen/iri-gen';
 import { UnauthorizedError } from '../errors';
+import { ensureLoggedIn } from '../middleware/passport';
 const router = express.Router();
 
 export const bucketName = process.env.AWS_S3_BUCKET;
 const region = process.env.AWS_BUCKET_REGION;
 const PROJECTS_PATH = process.env.S3_PROJECTS_PATH || 'projects';
+const PROFILES_PATH = process.env.S3_PROFILES_PATH || 'profiles';
 
 const s3 = new S3Client({
   region,
@@ -136,20 +138,25 @@ router.post(
 );
 
 router.delete(
-  '/files/:projectId/:fileName',
+  '/files/:path/:projectOrAccountId',
+  ensureLoggedIn(),
   bodyParser.json(),
   async (request: UserRequest, response: express.Response, next) => {
     let client: undefined | PoolClient;
+
     try {
-      const projectId = request.params.projectId;
-      const fileName = request.params.fileName;
+      const path = request.params.path;
+      const projectOrAccountId = request.params.projectOrAccountId;
+      const fileName = request.query.fileName;
 
       client = await pgPool.connect();
       await deleteFile({
+        path,
         client,
-        accountId: request.user?.accountId,
-        fileName,
-        projectId,
+        currentAccountId: request.user?.accountId,
+        fileName: fileName as string,
+        projectId: path === PROJECTS_PATH ? projectOrAccountId : undefined,
+        accountId: path === PROFILES_PATH ? projectOrAccountId : undefined,
         bucketName,
       });
       response.send('File successfully deleted');
@@ -220,32 +227,45 @@ function getExifLocationData(path: string | Buffer): Promise<Exif.ExifData> {
 }
 
 type DeleteFileParams = {
+  path?: string;
   bucketName?: string;
   client: PoolClient;
+  currentAccountId?: string;
   accountId?: string;
-  projectId: string;
+  projectId?: string;
   fileName: string;
 };
 
 export async function deleteFile({
+  path = PROJECTS_PATH,
   bucketName,
   client,
-  accountId,
+  currentAccountId,
   fileName,
   projectId,
+  accountId,
 }: DeleteFileParams) {
-  // Only the project admin is allowed to delete a project file
-  const queryRes = await client.query(
-    'SELECT project.id FROM project JOIN account ON account.id = project.admin_account_id WHERE account.id = $1 AND project.id = $2',
-    [accountId, projectId],
-  );
-  if (queryRes.rowCount !== 1) {
+  if (projectId) {
+    // Only the project admin is allowed to delete a project file
+    const queryRes = await client.query(
+      'SELECT project.id FROM project JOIN account ON account.id = project.admin_account_id WHERE account.id = $1 AND project.id = $2',
+      [currentAccountId, projectId],
+    );
+    if (queryRes.rowCount !== 1) {
+      throw new UnauthorizedError('unauthorized');
+    }
+  } else if (accountId) {
+    // Only the profile owner can delete a profile file
+    if (currentAccountId !== accountId) {
+      throw new UnauthorizedError('unauthorized');
+    }
+  } else {
     throw new UnauthorizedError('unauthorized');
   }
 
   const input: DeleteObjectCommandInput = {
     Bucket: bucketName,
-    Key: `${PROJECTS_PATH}/${projectId}/${fileName}`,
+    Key: `${path}/${projectId ?? accountId}/${fileName}`,
   };
   const cmd = new DeleteObjectCommand(input);
   const cmdResp = await s3.send(cmd);
@@ -256,7 +276,7 @@ export async function deleteFile({
   } else {
     const url = getFileUrl({
       bucketName,
-      path: `${PROJECTS_PATH}/${projectId}`,
+      path: `${path}/${projectId ?? accountId}`,
       fileName,
     });
     await client.query(`delete from upload where url = $1`, [url]);


### PR DESCRIPTION
## Description

The /files DELETE endpoint was only supporting projects media deletion, now it supports profile media deletion too (profile and background images).

ref: https://regennetwork.atlassian.net/browse/APP-114?atlOrigin=eyJpIjoiOGE2YzJkZTgzMjE2NDVlNGE3NGUxZjYyMmY0YmI1ZDQiLCJwIjoiaiJ9

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted `dev` branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed
- [ ] submit a PR against `master` branch after this one (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
